### PR TITLE
Don't always generate WebP

### DIFF
--- a/src/LaravelShortPixel.php
+++ b/src/LaravelShortPixel.php
@@ -84,6 +84,6 @@ class LaravelShortPixel
             $this->resize($width, $height, $max);
         }
 
-        return $this->file->generateWebP()->toFiles($path, $filename);
+        return $this->file->toFiles($path, $filename);
     }
 }


### PR DESCRIPTION
Instead, utilise the convertto config provided in shortpixel.php to allow users to supply webp/avif if required to prevent multiple credits being used in scenarios where customers are using "one time credits, rather than the monthly credits".


```
return [

    'api_key' => env('SHORT_PIXEL_API_KEY', null),

    'default_path' => storage_path(),

    'compression_level' => 2, // 0 - loseless, 1 - lossy, 2 - glossy

    'convertto' => '', // if '+webp' then also the WebP version will be generated

    'keep_exif' => 0, // 1 - EXIF is preserved, 0 - EXIF is removed

];
```


![image](https://github.com/davidcb/laravel-shortpixel/assets/6383356/b44d952c-9af7-4241-a4d9-d25ace19482b)