### PR TITLE
Added 'refresh' parameter to fromFiles, fromUrls, and fromFolder methods

### DIFF
--- a/src/LaravelShortPixel.php
+++ b/src/LaravelShortPixel.php
@@ -25,17 +25,17 @@ class LaravelShortPixel
         }
     }
 
-    public function fromUrls($url, $path = null, $filename = null, $level = null, $width = null, $height = null, $max = false)
+    public function fromUrls($url, $path = null, $filename = null, $level = null, $width = null, $height = null, $max = false, $refresh=false)
     {
         if (!$path) {
             $path = config('shortpixel.default_path');
         }
 
         $this->file = ShortPixel\fromUrls($url);
-        return $this->save($path, $filename, $level, $width, $height, $max);
+        return $this->save($path, $filename, $level, $width, $height, $max, $refresh);
     }
 
-    public function fromFiles($url, $path = null, $level = null, $width = null, $height = null, $max = false)
+    public function fromFiles($url, $path = null, $level = null, $width = null, $height = null, $max = false, $refresh=false)
     {
         if (!$path) {
             $path = config('shortpixel.default_path');
@@ -47,10 +47,10 @@ class LaravelShortPixel
             $this->file = ShortPixel\fromFiles($url);
         }
 
-        return $this->save($path, null, $level, $width, $height, $max);
+        return $this->save($path, null, $level, $width, $height, $max, $refresh);
     }
 
-    public function fromFolder($folder, $path = null, $level = null, $width = null, $height = null, $max = false)
+    public function fromFolder($folder, $path = null, $level = null, $width = null, $height = null, $max = false, $refresh=false)
     {
         \ShortPixel\ShortPixel::setOptions(array("persist_type" => "text"));
 
@@ -59,7 +59,7 @@ class LaravelShortPixel
         }
 
         $this->file = ShortPixel\fromFolder($folder)->wait(300);
-        return $this->save($path, null, $level, $width, $height, $max);
+        return $this->save($path, null, $level, $width, $height, $max, $refresh);
     }
 
     private function optimize($level = null)
@@ -76,12 +76,20 @@ class LaravelShortPixel
         return $this->file->resize($width, $height, $max);
     }
 
-    private function save($path, $filename = null, $level = null, $width = null, $height = null, $max = false)
+    private function refresh(){
+        return $this->file->refresh();
+    }
+
+    private function save($path, $filename = null, $level = null, $width = null, $height = null, $max = false, $refresh=false)
     {
         $this->optimize($level);
 
         if ($width && $height) {
             $this->resize($width, $height, $max);
+        }
+
+        if ($refresh) {
+            $this->refresh();
         }
 
         return $this->file->toFiles($path, $filename);


### PR DESCRIPTION
- Introduced a $refresh parameter (default: false) to the fromFiles, fromUrls, and fromFolder methods.
- When set to 	true, the methods will re-optimize already optimized images by sending a refresh request to ShortPixel.
- When set to false, the methods will not send a refresh request to ShortPixel for already optimized images.